### PR TITLE
Redo modifiers and BPM changes

### DIFF
--- a/prefabs/AnimationKeyframe.gd
+++ b/prefabs/AnimationKeyframe.gd
@@ -1,6 +1,7 @@
 extends Node2D
 
 var data: Dictionary
+var beat: float
 
 var move_pos: bool
 var mouse_pos: float
@@ -23,6 +24,7 @@ func _process(_delta):
 func setup(keyframe_data):
 	move_pos = false
 	data = keyframe_data
+	beat = Global.get_beat_at_time(data['timestamp'])
 	if data['animations']['normal'] == data['animations']['horny']:
 		$InputHandler.tooltip_text = data['animations']['horny']
 	else:
@@ -40,7 +42,8 @@ func setup(keyframe_data):
 		update_position()
 
 func update_position():
-	position.x = -((data['timestamp'] - Global.offset - Global.bpm_offset) * Global.note_speed)
+	data['timestamp'] = Global.get_time_at_beat(beat)
+	position.x = -((data['timestamp'] - Global.offset) * Global.note_speed)
 
 func _on_input_handler_gui_input(event):
 	if event is InputEventMouseButton:

--- a/prefabs/BackgroundKeyframe.gd
+++ b/prefabs/BackgroundKeyframe.gd
@@ -1,6 +1,7 @@
 extends Node2D
 
 var data: Dictionary
+var beat: float
 
 var move_pos: bool
 var mouse_pos: float
@@ -25,6 +26,7 @@ func _process(_delta):
 func setup(keyframe_data):
 	move_pos = false
 	data = keyframe_data
+	beat = Global.get_beat_at_time(data['timestamp'])
 	$InputHandler.tooltip_text = data['path']
 	$Thumb.texture = Assets.get_asset(data['path'])
 	if $Thumb.texture:
@@ -37,7 +39,8 @@ func setup(keyframe_data):
 		update_position()
 
 func update_position():
-	position.x = -((data['timestamp'] - Global.offset - Global.bpm_offset) * Global.note_speed)
+	data['timestamp'] = Global.get_time_at_beat(beat)
+	position.x = -((data['timestamp'] - Global.offset) * Global.note_speed)
 
 func _on_input_handler_gui_input(event):
 	if event is InputEventMouseButton:

--- a/prefabs/EffectKeyframe.gd
+++ b/prefabs/EffectKeyframe.gd
@@ -1,6 +1,7 @@
 extends Node2D
 
 var data: Dictionary
+var beat: float
 
 var move_pos: bool
 var mouse_pos: float
@@ -23,6 +24,7 @@ func _process(_delta):
 func setup(keyframe_data):
 	move_pos = false
 	data = keyframe_data
+	beat = Global.get_beat_at_time(data['timestamp'])
 	$InputHandler.tooltip_text = data['path']
 	$Thumb.texture = Assets.get_asset(data['path'])
 	if $Thumb.texture:
@@ -37,7 +39,8 @@ func setup(keyframe_data):
 		update_position()
 
 func update_position():
-	position.x = -((data['timestamp'] - Global.offset - Global.bpm_offset) * Global.note_speed)
+	data['timestamp'] = Global.get_time_at_beat(beat)
+	position.x = -((data['timestamp'] - Global.offset) * Global.note_speed)
 
 func _on_input_handler_gui_input(event):
 	if event is InputEventMouseButton:

--- a/prefabs/Guideline.gd
+++ b/prefabs/Guideline.gd
@@ -6,7 +6,7 @@ var indicator_type: int
 func _ready():
 	Events.update_notespeed.connect(update_position)
 	Events.update_snapping.connect(_on_update_snapping)
-	Events.update_bpm.connect(update_indicator)
+	Events.update_bpm.connect(update_position)
 
 func setup(i, type):
 	indicator_index = i
@@ -16,23 +16,17 @@ func setup(i, type):
 func update_position():
 	match indicator_type:
 		Enums.UI_INDICATOR_TYPE.BEAT:
-			if Save.keyframes['modifiers'].size() > 1: position.x = -(indicator_index * Global.beat_length_msec - Global.offset + Global.beat_offset) * Global.note_speed
-			else: position.x = -(indicator_index * Global.beat_length_msec - Global.offset) * Global.note_speed
+			position.x = -(Global.get_time_at_beat(indicator_index) - Global.offset) * Global.note_speed
 		Enums.UI_INDICATOR_TYPE.HALF_BEAT:
-			if Save.keyframes['modifiers'].size() > 1: position.x = -(indicator_index * Global.beat_length_msec/2 - Global.offset + Global.beat_offset) * Global.note_speed
-			else: position.x = -(indicator_index * Global.beat_length_msec/2 - Global.offset) * Global.note_speed
+			position.x = -(Global.get_time_at_beat(indicator_index/2.0) - Global.offset) * Global.note_speed
 		Enums.UI_INDICATOR_TYPE.THIRD_BEAT:
-			if Save.keyframes['modifiers'].size() > 1: position.x = -(indicator_index * Global.beat_length_msec/3 - Global.offset + Global.beat_offset) * Global.note_speed
-			else: position.x = -(indicator_index * Global.beat_length_msec/3 - Global.offset) * Global.note_speed
+			position.x = -(Global.get_time_at_beat(indicator_index/3.0) - Global.offset) * Global.note_speed
 		Enums.UI_INDICATOR_TYPE.QUARTER_BEAT:
-			if Save.keyframes['modifiers'].size() > 1: position.x = -(indicator_index * Global.beat_length_msec/4 - Global.offset + Global.beat_offset) * Global.note_speed
-			else: position.x = -(indicator_index * Global.beat_length_msec/4 - Global.offset) * Global.note_speed
+			position.x = -(Global.get_time_at_beat(indicator_index/4.0) - Global.offset) * Global.note_speed
 		Enums.UI_INDICATOR_TYPE.SIXTH_BEAT:
-			if Save.keyframes['modifiers'].size() > 1: position.x = -(indicator_index * Global.beat_length_msec/6 - Global.offset + Global.beat_offset) * Global.note_speed
-			else: position.x = -(indicator_index * Global.beat_length_msec/6 - Global.offset) * Global.note_speed
+			position.x = -(Global.get_time_at_beat(indicator_index/6.0) - Global.offset) * Global.note_speed
 		Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT:
-			if Save.keyframes['modifiers'].size() > 1: position.x = -(indicator_index * Global.beat_length_msec/8 - Global.offset + Global.beat_offset) * Global.note_speed
-			else: position.x = -(indicator_index * Global.beat_length_msec/8 - Global.offset) * Global.note_speed
+			position.x = -(Global.get_time_at_beat(indicator_index/8.0) - Global.offset) * Global.note_speed
 
 func _on_update_snapping(index):
 	# 1/3rds and 1/6ths are special cases
@@ -40,7 +34,7 @@ func _on_update_snapping(index):
 		modulate = Color(1,1,1,0)
 	elif indicator_type == Enums.UI_INDICATOR_TYPE.QUARTER_BEAT and index == 4:
 		modulate = Color(1,1,1,0)
-	elif indicator_type == Enums.UI_INDICATOR_TYPE.THIRD_BEAT and (index == 3 or index == 6):
+	elif indicator_type == Enums.UI_INDICATOR_TYPE.THIRD_BEAT and (index == 3 or index == 5):
 		modulate = Color(1,1,1,0)
 	elif indicator_type == Enums.UI_INDICATOR_TYPE.SIXTH_BEAT and index == 5:
 		modulate = Color(1,1,1,0)
@@ -48,13 +42,6 @@ func _on_update_snapping(index):
 		modulate = Color(1,1,1,1)
 	else:
 		modulate = Color(1,1,1,0)
-	update_indicator()
 
 func _process(_delta):
 	visible = global_position.x >= Global.note_culling_bounds.x and global_position.x < Global.note_culling_bounds.y
-
-func update_indicator():
-	if Save.keyframes['modifiers'].size() > 1:
-		var idx = Global.bpm_index; if idx < 1: idx = 1
-		if idx < Save.keyframes['modifiers'].size(): if position.x < Timeline.modifier_track.get_child(idx).position.x: modulate = Color(1,1,1,0)
-		else: idx = Save.keyframes['modifiers'].size()-1

--- a/prefabs/Indicator.gd
+++ b/prefabs/Indicator.gd
@@ -6,7 +6,7 @@ var indicator_type: int
 func _ready():
 	Events.update_notespeed.connect(update_position)
 	Events.update_snapping.connect(_on_update_snapping)
-	Events.update_bpm.connect(update_indicator)
+	Events.update_bpm.connect(update_position)
 
 func setup(i, type):
 	indicator_index = i
@@ -38,23 +38,17 @@ func setup(i, type):
 func update_position():
 	match indicator_type:
 		Enums.UI_INDICATOR_TYPE.BEAT:
-			if Save.keyframes['modifiers'].size() > 1: position.x = -(indicator_index * Global.beat_length_msec - Global.offset + Global.beat_offset) * Global.note_speed
-			else: position.x = -(indicator_index * Global.beat_length_msec - Global.offset) * Global.note_speed
+			position.x = -(Global.get_time_at_beat(indicator_index) - Global.offset) * Global.note_speed
 		Enums.UI_INDICATOR_TYPE.HALF_BEAT:
-			if Save.keyframes['modifiers'].size() > 1: position.x = -(indicator_index * Global.beat_length_msec/2 - Global.offset + Global.beat_offset) * Global.note_speed
-			else: position.x = -(indicator_index * Global.beat_length_msec/2 - Global.offset) * Global.note_speed
+			position.x = -(Global.get_time_at_beat(indicator_index/2.0) - Global.offset) * Global.note_speed
 		Enums.UI_INDICATOR_TYPE.THIRD_BEAT:
-			if Save.keyframes['modifiers'].size() > 1: position.x = -(indicator_index * Global.beat_length_msec/3 - Global.offset + Global.beat_offset) * Global.note_speed
-			else: position.x = -(indicator_index * Global.beat_length_msec/3 - Global.offset) * Global.note_speed
+			position.x = -(Global.get_time_at_beat(indicator_index/3.0) - Global.offset) * Global.note_speed
 		Enums.UI_INDICATOR_TYPE.QUARTER_BEAT:
-			if Save.keyframes['modifiers'].size() > 1: position.x = -(indicator_index * Global.beat_length_msec/4 - Global.offset + Global.beat_offset) * Global.note_speed
-			else: position.x = -(indicator_index * Global.beat_length_msec/4 - Global.offset) * Global.note_speed
+			position.x = -(Global.get_time_at_beat(indicator_index/4.0) - Global.offset) * Global.note_speed
 		Enums.UI_INDICATOR_TYPE.SIXTH_BEAT:
-			if Save.keyframes['modifiers'].size() > 1: position.x = -(indicator_index * Global.beat_length_msec/6 - Global.offset + Global.beat_offset) * Global.note_speed
-			else: position.x = -(indicator_index * Global.beat_length_msec/6 - Global.offset) * Global.note_speed
+			position.x = -(Global.get_time_at_beat(indicator_index/6.0) - Global.offset) * Global.note_speed
 		Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT:
-			if Save.keyframes['modifiers'].size() > 1: position.x = -(indicator_index * Global.beat_length_msec/8 - Global.offset + Global.beat_offset) * Global.note_speed
-			else: position.x = -(indicator_index * Global.beat_length_msec/8 - Global.offset) * Global.note_speed
+			position.x = -(Global.get_time_at_beat(indicator_index/8.0) - Global.offset) * Global.note_speed
 
 func _on_update_snapping(index):
 	# 1/3rds and 1/6ths are special cases
@@ -62,7 +56,7 @@ func _on_update_snapping(index):
 		modulate = Color(1,1,1,0)
 	elif indicator_type == Enums.UI_INDICATOR_TYPE.QUARTER_BEAT and index == 4:
 		modulate = Color(1,1,1,0)
-	elif indicator_type == Enums.UI_INDICATOR_TYPE.THIRD_BEAT and (index == 3 or index == 6):
+	elif indicator_type == Enums.UI_INDICATOR_TYPE.THIRD_BEAT and (index == 3 or index == 5):
 		modulate = Color(1,1,1,0)
 	elif indicator_type == Enums.UI_INDICATOR_TYPE.SIXTH_BEAT and index == 5:
 		modulate = Color(1,1,1,0)
@@ -70,18 +64,6 @@ func _on_update_snapping(index):
 		modulate = Color(1,1,1,1)
 	else:
 		modulate = Color(1,1,1,0)
-	update_indicator()
 
 func _process(_delta):
 	visible = global_position.x >= Global.note_culling_bounds.x and global_position.x < Global.note_culling_bounds.y
-
-func update_indicator():
-	if Save.keyframes['modifiers'].size() > 1:
-		var idx = Global.bpm_index; if idx < 1: idx = 1
-		if idx < Save.keyframes['modifiers'].size(): if position.x < Timeline.modifier_track.get_child(idx).position.x: modulate = Color(1,1,1,0)
-		else: idx = Save.keyframes['modifiers'].size()-1
-		
-		var beat = (Global.song_length - Global.offset) / Global.song_seconds_per_beat
-		$BeatNum.text = str(indicator_index + int(beat) - Global.song_beats_total)
-	else:
-		$BeatNum.text = str(indicator_index)

--- a/prefabs/Note.gd
+++ b/prefabs/Note.gd
@@ -2,6 +2,7 @@ extends Node2D
 
 var hit: bool
 var data: Dictionary
+var beat: float
 
 var move_pos: bool
 var mouse_pos: float
@@ -12,16 +13,19 @@ var selected_note: Node2D
 
 func _ready():
 	Events.update_notespeed.connect(update_position)
+	Events.update_bpm.connect(update_position)
 
 func setup(note_data):
 	data = note_data
 	move_pos = false
 	clear_clipboard = false
+	beat = Global.get_beat_at_time(data['timestamp'])
 	update_visual()
 	update_position()
 
 func update_position():
-	position.x = -((data['timestamp'] - Global.offset - Global.bpm_offset) * Global.note_speed)
+	data['timestamp'] = Global.get_time_at_beat(beat)
+	position.x = -((data['timestamp'] - Global.offset) * Global.note_speed)
 
 func _input(event):
 	if event is InputEventKey: clear_clipboard = !event.is_command_or_control_pressed()
@@ -148,6 +152,7 @@ func horny_add():
 		data['horny']['required'] += 1
 	update_visual()
 	Events.emit_signal('tool_used_after', data)
+
 func horny_remove():
 	Events.emit_signal('tool_used_before', data)
 	if data.has('horny') and data['horny'].has('required'):
@@ -157,6 +162,7 @@ func horny_remove():
 			data['horny']['required'] -= 1
 	update_visual()
 	Events.emit_signal('tool_used_after', data)
+
 func toggle_voice_trigger():
 	Events.emit_signal('tool_used_before', data)
 	if data.has('trigger_voice'):
@@ -165,6 +171,7 @@ func toggle_voice_trigger():
 		data['trigger_voice'] = true
 	update_visual()
 	Events.emit_signal('tool_used_after', data)
+
 func modify_cycle(i):
 	Events.emit_signal('tool_used_before', data)
 	data['note_modifier'] = wrapi(data['note_modifier'] + i, 0, 3)

--- a/prefabs/OneshotSoundKeyframe.gd
+++ b/prefabs/OneshotSoundKeyframe.gd
@@ -1,6 +1,7 @@
 extends Node2D
 
 var data: Dictionary
+var beat: float
 
 var move_pos: bool
 var mouse_pos: float
@@ -10,6 +11,7 @@ var selected_key: Node2D
 
 func _ready():
 	Events.update_notespeed.connect(update_position)
+	Events.update_bpm.connect(update_position)
 
 func _process(_delta):
 	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
@@ -23,11 +25,13 @@ func _process(_delta):
 func setup(keyframe_data):
 	move_pos = false
 	data = keyframe_data
+	beat = Global.get_beat_at_time(data['timestamp'])
 	$InputHandler.tooltip_text = data['path']
 	update_position()
 
 func update_position():
-	position.x = -((data['timestamp'] - Global.offset - Global.bpm_offset) * Global.note_speed)
+	data['timestamp'] = Global.get_time_at_beat(beat)
+	position.x = -((data['timestamp'] - Global.offset) * Global.note_speed)
 
 func _on_input_handler_gui_input(event):
 	if event is InputEventMouseButton:

--- a/prefabs/ShutterKeyframe.gd
+++ b/prefabs/ShutterKeyframe.gd
@@ -1,6 +1,7 @@
 extends Node2D
 
 var data: Dictionary
+var beat: float
 
 var move_pos: bool
 var mouse_pos: float
@@ -10,6 +11,7 @@ var selected_key: Node2D
 
 func _ready():
 	Events.update_notespeed.connect(update_position)
+	Events.update_bpm.connect(update_position)
 
 func _process(_delta):
 	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
@@ -23,10 +25,12 @@ func _process(_delta):
 func setup(keyframe_data):
 	move_pos = false
 	data = keyframe_data
+	beat = Global.get_beat_at_time(data['timestamp'])
 	update_position()
 
 func update_position():
-	position.x = -((data['timestamp'] - Global.offset - Global.bpm_offset) * Global.note_speed)
+	data['timestamp'] = Global.get_time_at_beat(beat)
+	position.x = -((data['timestamp'] - Global.offset) * Global.note_speed)
 
 func _on_input_handler_gui_input(event) -> void:
 	if event is InputEventMouseButton:

--- a/prefabs/SoundLoopKeyframe.gd
+++ b/prefabs/SoundLoopKeyframe.gd
@@ -1,6 +1,7 @@
 extends Node2D
 
 var data: Dictionary
+var beat: float
 
 var move_pos: bool
 var mouse_pos: float
@@ -10,6 +11,7 @@ var selected_key: Node2D
 
 func _ready():
 	Events.update_notespeed.connect(update_position)
+	Events.update_bpm.connect(update_position)
 
 func _process(_delta):
 	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
@@ -23,11 +25,13 @@ func _process(_delta):
 func setup(keyframe_data):
 	move_pos = false
 	data = keyframe_data
+	beat = Global.get_beat_at_time(data['timestamp'])
 	$InputHandler.tooltip_text = data['path']
 	update_position()
 
 func update_position():
-	position.x = -((data['timestamp'] - Global.offset - Global.bpm_offset) * Global.note_speed)
+	data['timestamp'] = Global.get_time_at_beat(beat)
+	position.x = -((data['timestamp'] - Global.offset) * Global.note_speed)
 
 func _on_input_handler_gui_input(event):
 	if event is InputEventMouseButton:

--- a/prefabs/VoiceBankKeyframe.gd
+++ b/prefabs/VoiceBankKeyframe.gd
@@ -1,6 +1,7 @@
 extends Node2D
 
 var data: Dictionary
+var beat: float
 
 var move_pos: bool
 var mouse_pos: float
@@ -10,6 +11,7 @@ var selected_key: Node2D
 
 func _ready():
 	Events.update_notespeed.connect(update_position)
+	Events.update_bpm.connect(update_position)
 
 func _process(_delta):
 	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
@@ -23,6 +25,7 @@ func _process(_delta):
 func setup(keyframe_data):
 	move_pos = false
 	data = keyframe_data
+	beat = Global.get_beat_at_time(data['timestamp'])
 	var voice_paths:String = ''
 	for i in data['voice_paths'].size():
 		voice_paths += data['voice_paths'][i]
@@ -31,7 +34,8 @@ func setup(keyframe_data):
 	update_position()
 
 func update_position():
-	position.x = -((data['timestamp'] - Global.offset - Global.bpm_offset) * Global.note_speed)
+	data['timestamp'] = Global.get_time_at_beat(beat)
+	position.x = -((data['timestamp'] - Global.offset) * Global.note_speed)
 
 func _on_input_handler_gui_input(event):
 	if event is InputEventMouseButton:

--- a/src/cl_keycontroller.gd
+++ b/src/cl_keycontroller.gd
@@ -98,40 +98,40 @@ func create_ui():
 		new_key_indicator.setup(i, Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT)
 
 func reset_indicators():
-	var difference = Global.song_beats_total - $Beat.get_child_count()
+	var difference = Global.song_beats_total + 1 - $Beat.get_child_count()
 	if difference != 0:
 		for i in range(Global.song_beats_total - difference + 1, Global.song_beats_total + 1, 1 if difference>0 else -1):
 			if difference > 0:
-				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-				$Beat.add_child(new_beat_indicator)
-				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.BEAT)
+				var new_key_indicator = Prefabs.key_indicator.instantiate()
+				$Beat.add_child(new_key_indicator)
+				new_key_indicator.setup(i, Enums.UI_INDICATOR_TYPE.BEAT)
 			else:
 				$Beat.remove_child($Beat.get_child($Beat.get_child_count()-1))
 	
 		for i in range((Global.song_beats_total - difference) * 2, Global.song_beats_total * 2, 1 if difference>0 else -1):
 			if i % 2 == 0: continue
 			if difference > 0:
-				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-				$Half.add_child(new_beat_indicator)
-				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.HALF_BEAT)
+				var new_key_indicator = Prefabs.key_indicator.instantiate()
+				$Half.add_child(new_key_indicator)
+				new_key_indicator.setup(i, Enums.UI_INDICATOR_TYPE.HALF_BEAT)
 			else:
 				$Half.remove_child($Half.get_child($Half.get_child_count()-1))
 	
 		for i in range((Global.song_beats_total - difference) * 3, Global.song_beats_total * 3, 1 if difference>0 else -1):
 			if i % 3 == 0: continue
 			if difference > 0:
-				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-				$Third.add_child(new_beat_indicator)
-				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.THIRD_BEAT)
+				var new_key_indicator = Prefabs.key_indicator.instantiate()
+				$Third.add_child(new_key_indicator)
+				new_key_indicator.setup(i, Enums.UI_INDICATOR_TYPE.THIRD_BEAT)
 			else:
 				$Third.remove_child($Third.get_child($Third.get_child_count()-1))
 	
 		for i in range((Global.song_beats_total - difference) * 4, Global.song_beats_total * 4, 1 if difference>0 else -1):
 			if i % 2 == 0: continue
 			if difference > 0:
-				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-				$Quarter.add_child(new_beat_indicator)
-				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.QUARTER_BEAT)
+				var new_key_indicator = Prefabs.key_indicator.instantiate()
+				$Quarter.add_child(new_key_indicator)
+				new_key_indicator.setup(i, Enums.UI_INDICATOR_TYPE.QUARTER_BEAT)
 			else:
 				$Quarter.remove_child($Quarter.get_child($Quarter.get_child_count()-1))
 	
@@ -139,18 +139,18 @@ func reset_indicators():
 			if i % 3 == 0: continue
 			if i % 2 == 0: continue
 			if difference > 0:
-				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-				$Sixth.add_child(new_beat_indicator)
-				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.SIXTH_BEAT)
+				var new_key_indicator = Prefabs.key_indicator.instantiate()
+				$Sixth.add_child(new_key_indicator)
+				new_key_indicator.setup(i, Enums.UI_INDICATOR_TYPE.SIXTH_BEAT)
 			else:
 				$Sixth.remove_child($Sixth.get_child($Sixth.get_child_count()-1))
 	
 		for i in range((Global.song_beats_total - difference) * 8, Global.song_beats_total * 8, 1 if difference>0 else -1):
 			if i % 2 == 0: continue
 			if difference > 0:
-				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-				$Eighth.add_child(new_beat_indicator)
-				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT)
+				var new_key_indicator = Prefabs.key_indicator.instantiate()
+				$Eighth.add_child(new_key_indicator)
+				new_key_indicator.setup(i, Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT)
 			else:
 				$Eighth.remove_child($Eighth.get_child($Eighth.get_child_count()-1))
 

--- a/src/cl_keycontroller.gd
+++ b/src/cl_keycontroller.gd
@@ -2,7 +2,6 @@ extends Node2D
 
 var note_pos: float
 var note_offset: float
-var bpm_offset: float
 
 func _ready():
 	# Globalize Tracks
@@ -37,7 +36,6 @@ func _on_song_loaded():
 	spawn_keyframes('sound_loop', Prefabs.sfx_keyframe, Timeline.sfx_track)
 	spawn_keyframes('sound_oneshot', Prefabs.oneshot_keyframe, Timeline.oneshot_sound_track)
 	spawn_keyframes('voice_bank', Prefabs.voice_keyframe, Timeline.voice_banks_track)
-	
 	Global.clear_children(Timeline.key_beat_container)
 	Global.clear_children(Timeline.key_half_container)
 	Global.clear_children(Timeline.key_third_container)
@@ -100,132 +98,67 @@ func create_ui():
 		new_key_indicator.setup(i, Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT)
 
 func reset_indicators():
-	var difference = Global.song_beats_total*8 - $Eighth.get_child_count()*2
-	if difference > 0:
-		for i in difference+1:
-			if i % 8 == 0: continue
-			if i % 4 == 0: continue
+	var difference = Global.song_beats_total - $Beat.get_child_count()
+	if difference != 0:
+		for i in range(Global.song_beats_total - difference + 1, Global.song_beats_total + 1, 1 if difference>0 else -1):
+			if difference > 0:
+				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
+				$Beat.add_child(new_beat_indicator)
+				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.BEAT)
+			else:
+				$Beat.remove_child($Beat.get_child($Beat.get_child_count()-1))
+	
+		for i in range((Global.song_beats_total - difference) * 2, Global.song_beats_total * 2, 1 if difference>0 else -1):
 			if i % 2 == 0: continue
-			var index = $Beat.get_child_count()*8-8+i
-			if $Eighth.get_child($Eighth.get_child_count()-1).indicator_index == index: index += 1
-			if $Quarter.get_child($Quarter.get_child_count()-1).indicator_index*2 == index: index += 1
-			if $Eighth.get_child($Eighth.get_child_count()-1).indicator_index-2 == index: index += 4
-			if $Quarter.get_child($Quarter.get_child_count()-1).indicator_index*2-5 == index: index += 6
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup(index, Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT)
-			$Eighth.add_child(new_key_indicator)
-	elif difference < 0:
-		for beat in $Eighth.get_children():
-			if beat.get_index() > float(Global.song_beats_total*8-1)/2: $Eighth.remove_child(beat)
+			if difference > 0:
+				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
+				$Half.add_child(new_beat_indicator)
+				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.HALF_BEAT)
+			else:
+				$Half.remove_child($Half.get_child($Half.get_child_count()-1))
 	
-	difference = Global.song_beats_total*6 - $Sixth.get_child_count()*3
-	if difference > 0:
-		for i in difference+1:
-			if int(i) % 6 == 0: continue
-			if int(i) % 3 == 0: continue
-			if int(i) % 2 == 0: continue
-			var index = $Beat.get_child_count()*6-6+i
-			#if $Sixth.get_child($Sixth.get_child_count()-1).indicator_index == index: index += 1
-			#if $Third.get_child($Third.get_child_count()-1).indicator_index*2 == index: index += 1
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup(index, Enums.UI_INDICATOR_TYPE.SIXTH_BEAT)
-			$Sixth.add_child(new_key_indicator)
-	elif difference < 0:
-		for beat in $Sixth.get_children():
-			if beat.get_index() > float(Global.song_beats_total*6-1)/3: $Sixth.remove_child(beat)
+		for i in range((Global.song_beats_total - difference) * 3, Global.song_beats_total * 3, 1 if difference>0 else -1):
+			if i % 3 == 0: continue
+			if difference > 0:
+				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
+				$Third.add_child(new_beat_indicator)
+				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.THIRD_BEAT)
+			else:
+				$Third.remove_child($Third.get_child($Third.get_child_count()-1))
 	
-	difference = Global.song_beats_total*4 - $Quarter.get_child_count()*2
-	if difference > 0:
-		for i in difference+1:
-			if i % 4 == 0: continue
+		for i in range((Global.song_beats_total - difference) * 4, Global.song_beats_total * 4, 1 if difference>0 else -1):
 			if i % 2 == 0: continue
-			var index = $Beat.get_child_count()*4-4+i
-			if $Quarter.get_child($Quarter.get_child_count()-1).indicator_index == index: index += 2
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup(index, Enums.UI_INDICATOR_TYPE.QUARTER_BEAT)
-			$Quarter.add_child(new_key_indicator)
-	elif difference < 0:
-		for beat in $Quarter.get_children():
-			if beat.get_index() > float(Global.song_beats_total*4-1)/2: $Quarter.remove_child(beat)
+			if difference > 0:
+				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
+				$Quarter.add_child(new_beat_indicator)
+				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.QUARTER_BEAT)
+			else:
+				$Quarter.remove_child($Quarter.get_child($Quarter.get_child_count()-1))
 	
-	difference = Global.song_beats_total*3 - $Third.get_child_count()*1.5
-	if difference > 0:
-		for i in difference+1:
-			if int(i) % 3 == 0: continue
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup($Beat.get_child_count()*3-3+i, Enums.UI_INDICATOR_TYPE.THIRD_BEAT)
-			$Third.add_child(new_key_indicator)
-	elif difference < 0:
-		for beat in $Third.get_children():
-			if beat.get_index() > float(Global.song_beats_total*3-1)/1.5: $Third.remove_child(beat)
-	
-	difference = Global.song_beats_total*2 - $Half.get_child_count()*2
-	if difference > 0:
-		for i in difference+1:
+		for i in range((Global.song_beats_total - difference) * 6, Global.song_beats_total * 6, 1 if difference>0 else -1):
+			if i % 3 == 0: continue
 			if i % 2 == 0: continue
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup($Beat.get_child_count()*2-2+i, Enums.UI_INDICATOR_TYPE.HALF_BEAT)
-			$Half.add_child(new_key_indicator)
-	elif difference < 0:
-		for beat in $Half.get_children():
-			if beat.get_index() > float(Global.song_beats_total*2-1)/2: $Half.remove_child(beat)
+			if difference > 0:
+				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
+				$Sixth.add_child(new_beat_indicator)
+				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.SIXTH_BEAT)
+			else:
+				$Sixth.remove_child($Sixth.get_child($Sixth.get_child_count()-1))
 	
-	difference = Global.song_beats_total+1 - $Beat.get_child_count()
-	if difference > 0:
-		for i in difference:
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup($Beat.get_child_count(), Enums.UI_INDICATOR_TYPE.BEAT)
-			$Beat.add_child(new_key_indicator)
-	elif difference < 0:
-		for beat in $Beat.get_children():
-			if beat.get_index() > Global.song_beats_total: $Beat.remove_child(beat)
-	
-	var nega_beat = Global.beat_offset / Global.beat_length_msec
-	if nega_beat > 0 and nega_beat <= 1:
-		if nega_beat >= 0.125:
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup(-1,3)
-			$Eighth.add_child(new_key_indicator)
-		if nega_beat >= 0.25:
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup(-1,2)
-			$Quarter.add_child(new_key_indicator)
-		if nega_beat >= 0.375:
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup(-3,3)
-			$Eighth.add_child(new_key_indicator)
-		if nega_beat >= 0.5:
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup(-1,1)
-			$Half.add_child(new_key_indicator)
-		if nega_beat >= 0.625:
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup(-5,3)
-			$Eighth.add_child(new_key_indicator)
-		if nega_beat >= 0.75:
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup(-3,2)
-			$Quarter.add_child(new_key_indicator)
-		if nega_beat >= 0.875:
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup(-7,3)
-			$Eighth.add_child(new_key_indicator)
-		if nega_beat == 1:
-			var new_key_indicator = Prefabs.key_indicator.instantiate()
-			new_key_indicator.setup(-1,0)
-			$Beat.add_child(new_key_indicator)
-	else:
-		for beat in $Beat.get_children(): if beat.indicator_index < 0: $Beat.remove_child(beat)
-		for beat in $Half.get_children(): if beat.indicator_index < 0: $Half.remove_child(beat)
-		for beat in $Quarter.get_children(): if beat.indicator_index < 0: $Quarter.remove_child(beat)
-		for beat in $Eighth.get_children(): if beat.indicator_index < 0: $Eighth.remove_child(beat)
+		for i in range((Global.song_beats_total - difference) * 8, Global.song_beats_total * 8, 1 if difference>0 else -1):
+			if i % 2 == 0: continue
+			if difference > 0:
+				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
+				$Eighth.add_child(new_beat_indicator)
+				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT)
+			else:
+				$Eighth.remove_child($Eighth.get_child($Eighth.get_child_count()-1))
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):
 	note_pos = Global.song_pos * Global.note_speed
 	note_offset = Global.offset * Global.note_speed
-	bpm_offset = Global.bpm_offset * Global.note_speed
-	position.x = note_pos - note_offset - bpm_offset + 960
+	position.x = note_pos - note_offset + 960
 	
 	$ShutterPanel.position.x = -position.x; $ShutterGradient.position.x = -position.x
 	$AnimationsPanel.position.x = -position.x; $AnimationsGradient.position.x = -position.x

--- a/src/cl_menubar_add.gd
+++ b/src/cl_menubar_add.gd
@@ -26,7 +26,7 @@ func _on_id_pressed(id: int):
 			Global.project_saved = false
 		MODIFIER:
 			if time < 0: time = 0
-			var new_bpm = {'bpm': Global.bpm, 'timestamp': time}
+			var new_bpm = {'bpm': Global.get_current_bpm(), 'timestamp': time}
 			for bpm in Timeline.modifier_track.get_children():
 				if snappedf(bpm['data']['timestamp'], 0.001) == snappedf(time, 0.001):
 					if Global.replacing_allowed:

--- a/src/cl_notecontroller.gd
+++ b/src/cl_notecontroller.gd
@@ -82,7 +82,7 @@ func create_ui():
 	Events.emit_signal('update_snapping', Global.snapping_ratios.find(Global.snapping_factor))
 
 func reset_indicators():
-	var difference = Global.song_beats_total - $Beat.get_child_count()
+	var difference = Global.song_beats_total + 1 - $Beat.get_child_count()
 	if difference != 0:
 		for i in range(Global.song_beats_total - difference + 1, Global.song_beats_total + 1, 1 if difference>0 else -1):
 			if difference > 0:

--- a/src/cl_notecontroller.gd
+++ b/src/cl_notecontroller.gd
@@ -2,9 +2,7 @@ extends Node2D
 
 var note_pos: float
 var note_offset: float
-var bpm_offset: float
 
-var bpm_index: int
 var last_bpm_index: int
 
 var modifiers: int
@@ -33,7 +31,6 @@ func _on_chart_loaded():
 		$Notes.add_child(new_note)
 
 func _on_song_loaded():
-	bpm_index = 0; last_bpm_index = 0; Global.bpm_index = 0
 	modifiers = Timeline.modifier_track.get_child_count()
 	Global.clear_children(Timeline.beat_container)
 	Global.clear_children(Timeline.half_container)
@@ -85,133 +82,61 @@ func create_ui():
 	Events.emit_signal('update_snapping', Global.snapping_ratios.find(Global.snapping_factor))
 
 func reset_indicators():
-	var difference = Global.song_beats_total*8 - $Eighth.get_child_count()*2
-	if difference > 0:
-		for i in difference+1:
-			if i % 8 == 0: continue
-			if i % 4 == 0: continue
+	var difference = Global.song_beats_total - $Beat.get_child_count()
+	if difference != 0:
+		for i in range(Global.song_beats_total - difference + 1, Global.song_beats_total + 1, 1 if difference>0 else -1):
+			if difference > 0:
+				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
+				$Beat.add_child(new_beat_indicator)
+				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.BEAT)
+			else:
+				$Beat.remove_child($Beat.get_child($Beat.get_child_count()-1))
+	
+		for i in range((Global.song_beats_total - difference) * 2, Global.song_beats_total * 2, 1 if difference>0 else -1):
 			if i % 2 == 0: continue
-			var index = $Beat.get_child_count()*8-8+i
-			if $Eighth.get_child($Eighth.get_child_count()-1).indicator_index == index: index += 1
-			if $Quarter.get_child($Quarter.get_child_count()-1).indicator_index*2 == index: index += 1
-			if $Eighth.get_child($Eighth.get_child_count()-1).indicator_index-2 == index: index += 4
-			if $Quarter.get_child($Quarter.get_child_count()-1).indicator_index*2-5 == index: index += 6
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(index, Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT)
-			$Eighth.add_child(new_beat_indicator)
-	elif difference < 0:
-		for beat in $Eighth.get_children():
-			if beat.get_index() > float(Global.song_eighths_total-1)/2: $Eighth.remove_child(beat)
+			if difference > 0:
+				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
+				$Half.add_child(new_beat_indicator)
+				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.HALF_BEAT)
+			else:
+				$Half.remove_child($Half.get_child($Half.get_child_count()-1))
 	
-	difference = Global.song_beats_total*6 - $Sixth.get_child_count()*3
-	if difference > 0:
-		for i in difference+1:
-			if int(i) % 6 == 0: continue
-			if int(i) % 3 == 0: continue
-			if int(i) % 2 == 0: continue
-			var index = $Beat.get_child_count()*6-6+i
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(index, Enums.UI_INDICATOR_TYPE.SIXTH_BEAT)
-			$Sixth.add_child(new_beat_indicator)
-	elif difference < 0:
-		for beat in $Sixth.get_children():
-			if beat.get_index() > float(Global.song_beats_total*6-1)/3: $Sixth.remove_child(beat)
+		for i in range((Global.song_beats_total - difference) * 3, Global.song_beats_total * 3, 1 if difference>0 else -1):
+			if i % 3 == 0: continue
+			if difference > 0:
+				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
+				$Third.add_child(new_beat_indicator)
+				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.THIRD_BEAT)
+			else:
+				$Third.remove_child($Third.get_child($Third.get_child_count()-1))
 	
-	difference = Global.song_beats_total*4 - $Quarter.get_child_count()*2
-	if difference > 0:
-		for i in difference+1:
-			if i % 4 == 0: continue
+		for i in range((Global.song_beats_total - difference) * 4, Global.song_beats_total * 4, 1 if difference>0 else -1):
 			if i % 2 == 0: continue
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup($Beat.get_child_count()*4-4+i, Enums.UI_INDICATOR_TYPE.QUARTER_BEAT)
-			$Quarter.add_child(new_beat_indicator)
-	elif difference < 0:
-		for beat in $Quarter.get_children():
-			if beat.get_index() > float(Global.song_beats_total*4-1)/2: $Quarter.remove_child(beat)
+			if difference > 0:
+				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
+				$Quarter.add_child(new_beat_indicator)
+				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.QUARTER_BEAT)
+			else:
+				$Quarter.remove_child($Quarter.get_child($Quarter.get_child_count()-1))
 	
-	difference = Global.song_beats_total*3-1 - $Third.get_child_count()*1.5
-	if difference > 0:
-		for i in difference+1:
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup($Beat.get_child_count()*3-3+i, Enums.UI_INDICATOR_TYPE.THIRD_BEAT)
-			$Third.add_child(new_beat_indicator)
-	elif difference < 0:
-		for beat in $Third.get_children():
-			if beat.get_index() > float(Global.song_beats_total*3-1)/1.5: $Third.remove_child(beat)
-	
-	difference = Global.song_beats_total*2 - $Half.get_child_count()*2
-	if difference > 0:
-		for i in difference+1:
+		for i in range((Global.song_beats_total - difference) * 6, Global.song_beats_total * 6, 1 if difference>0 else -1):
+			if i % 3 == 0: continue
 			if i % 2 == 0: continue
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup($Beat.get_child_count()*2-2+i, Enums.UI_INDICATOR_TYPE.HALF_BEAT)
-			$Half.add_child(new_beat_indicator)
-	elif difference < 0:
-		for beat in $Half.get_children():
-			if beat.get_index() > float(Global.song_beats_total*2-1)/2: $Half.remove_child(beat)
+			if difference > 0:
+				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
+				$Sixth.add_child(new_beat_indicator)
+				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.SIXTH_BEAT)
+			else:
+				$Sixth.remove_child($Sixth.get_child($Sixth.get_child_count()-1))
 	
-	difference = Global.song_beats_total+1 - $Beat.get_child_count()
-	if difference > 0:
-		for i in difference:
-			var index = $Beat.get_child_count()
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(index, Enums.UI_INDICATOR_TYPE.BEAT)
-			$Beat.add_child(new_beat_indicator)
-	elif difference < 0:
-		for beat in $Beat.get_children():
-			if beat.get_index() > Global.song_beats_total: $Beat.remove_child(beat)
-	
-	var nega_beat = Global.beat_offset / Global.beat_length_msec
-	if nega_beat > 0 and nega_beat < 1:
-		if nega_beat >= 0.125:
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(-1, Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT)
-			$Eighth.add_child(new_beat_indicator)
-		if nega_beat >= 1.0/6.0:
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(-1, Enums.UI_INDICATOR_TYPE.SIXTH_BEAT)
-			$Sixth.add_child(new_beat_indicator)
-		if nega_beat >= 0.25:
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(-1, Enums.UI_INDICATOR_TYPE.QUARTER_BEAT)
-			$Quarter.add_child(new_beat_indicator)
-		if nega_beat >= 1.0/3.0:
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(-1, Enums.UI_INDICATOR_TYPE.THIRD_BEAT)
-			$Third.add_child(new_beat_indicator)
-		if nega_beat >= 0.375:
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(-3, Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT)
-			$Eighth.add_child(new_beat_indicator)
-		if nega_beat >= 0.5:
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(-1, Enums.UI_INDICATOR_TYPE.HALF_BEAT)
-			$Half.add_child(new_beat_indicator)
-		if nega_beat >= 2.0/3.0:
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(-1, Enums.UI_INDICATOR_TYPE.SIXTH_BEAT)
-			$Sixth.add_child(new_beat_indicator)
-		if nega_beat >= 0.625:
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(-5, Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT)
-			$Eighth.add_child(new_beat_indicator)
-		if nega_beat >= 0.75:
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(-3, Enums.UI_INDICATOR_TYPE.QUARTER_BEAT)
-			$Quarter.add_child(new_beat_indicator)
-		if nega_beat >= 0.875:
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(-7, Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT)
-			$Eighth.add_child(new_beat_indicator)
-		if nega_beat == 1:
-			var new_beat_indicator = Prefabs.beat_indicator.instantiate()
-			new_beat_indicator.setup(-1, Enums.UI_INDICATOR_TYPE.BEAT)
-			$Beat.add_child(new_beat_indicator)
-	else:
-		for beat in $Beat.get_children(): if beat.indicator_index < 0: $Beat.remove_child(beat)
-		for beat in $Half.get_children(): if beat.indicator_index < 0: $Half.remove_child(beat)
-		for beat in $Quarter.get_children(): if beat.indicator_index < 0: $Quarter.remove_child(beat)
-		for beat in $Eighth.get_children(): if beat.indicator_index < 0: $Eighth.remove_child(beat)
+		for i in range((Global.song_beats_total - difference) * 8, Global.song_beats_total * 8, 1 if difference>0 else -1):
+			if i % 2 == 0: continue
+			if difference > 0:
+				var new_beat_indicator = Prefabs.beat_indicator.instantiate()
+				$Eighth.add_child(new_beat_indicator)
+				new_beat_indicator.setup(i, Enums.UI_INDICATOR_TYPE.EIGHTH_BEAT)
+			else:
+				$Eighth.remove_child($Eighth.get_child($Eighth.get_child_count()-1))
 	
 	Events.emit_signal('update_snapping', Global.snapping_ratios.find(Global.snapping_factor))
 
@@ -219,8 +144,7 @@ func reset_indicators():
 func _process(_delta):
 	note_pos = Global.song_pos * Global.note_speed
 	note_offset = Global.offset * Global.note_speed
-	bpm_offset = Global.bpm_offset * Global.note_speed
-	position.x = note_pos - note_offset - bpm_offset
+	position.x = note_pos - note_offset
 	
 	$Gradient.position.x = -position.x - 960
 	$Label.position.x = -position.x - 944
@@ -234,28 +158,8 @@ func _on_note_created(new_note_data):
 
 # Changes BPM of the song for charting
 func _physics_process(_delta):
-	if Save.keyframes.has('modifiers') and Save.keyframes['modifiers'].size() > 0 and Timeline.modifier_track.get_child_count() > 0:
-		var arr = Save.keyframes['modifiers'].filter(func(bpm): return Global.song_pos >= bpm['timestamp'])
-		bpm_index = arr.size()
-		if bpm_index != last_bpm_index:
-			Global.bpm_index = bpm_index
-			change_bpm(bpm_index-1)
-			if Save.keyframes['modifiers'].size() <= 1: if last_bpm_index > 1: Global.reload_bpm()
-			last_bpm_index = bpm_index
-	
 	if modifiers != Timeline.modifier_track.get_child_count():
-		change_bpm(bpm_index-1)
 		modifiers = Timeline.modifier_track.get_child_count()
-
-func change_bpm(idx: int):
-	if idx < 0: idx = 0
-	Global.bpm = Save.keyframes['modifiers'][idx]['bpm']
-	Global.bpm_offset = Save.keyframes['modifiers'][idx]['timestamp']
-	var bpm = Save.keyframes['modifiers'][idx-1]['bpm']; var time = Save.keyframes['modifiers'][idx-1]['timestamp']
-	Global.beat_offset = (float(60.0/Global.bpm)-Global.bpm_offset) + (float(60.0/bpm)-time/(60.0/bpm))
-	if Global.beat_offset < 0: Global.beat_offset = 0
-	if Save.keyframes['modifiers'].size() > 1 and last_bpm_index >= 1 and bpm_index > 0: Global.reload_bpm(idx)
-	else: if Global.bpm != Global.global_bpm: Global.reload_bpm()
 
 func _on_update_bpm():
 	if Global.project_loaded: reset_indicators()

--- a/src/gl_global.gd
+++ b/src/gl_global.gd
@@ -121,7 +121,7 @@ func reload_bpm():
 		bpm_beatstamps.append(cumulativeBeats)
 		prevTimestamp = mod['timestamp']
 		prevBpm = mod['bpm']
-	song_beats_total = int(get_beat_at_time(song_length - offset))
+	song_beats_total = ceil(get_beat_at_time(song_length - offset))
 	
 	mods_need_reapply = true
 	

--- a/src/gl_global.gd
+++ b/src/gl_global.gd
@@ -71,7 +71,7 @@ func load_texture(path) -> ImageTexture:
 	return tex
 
 func get_timestamp_snapped(pos: float = song_pos) -> float:
-	return Global.get_time_at_beat(snappedf(Global.get_beat_at_time(pos), 1.0/snapping_factor))
+	return get_time_at_beat(snappedf(get_beat_at_time(pos), 1.0/snapping_factor))
 
 func get_mouse_timestamp() -> float:
 	var time = ((song_pos * note_speed) - mouse_pos)/note_speed
@@ -87,19 +87,19 @@ func get_mouse_timestamp_snapped() -> float:
 
 func get_current_bpm_timestamp() -> float:
 	var prevEntry = 0.0
-	for entry in Global.bpm_timestamps:
+	for entry in bpm_timestamps:
 		if entry > song_pos:
 			return prevEntry
 		prevEntry = entry
-	return Global.bpm_timestamps[-1]
+	return bpm_timestamps[-1]
 
 func get_current_bpm() -> float:
 	var prevEntry = 0.0
-	for i in Global.bpm_timestamps.size():
-		if Global.bpm_timestamps[i] > song_pos:
+	for i in bpm_timestamps.size():
+		if bpm_timestamps[i] > song_pos:
 			return prevEntry
-		prevEntry = Global.bpms[i]
-	return Global.bpms[-1]
+		prevEntry = bpms[i]
+	return bpms[-1]
 
 func clear_children(parent: Node):
 	print("Cleaning %s's children" % parent.name)
@@ -110,37 +110,37 @@ func reload_bpm():
 	var cumulativeBeats = 0.0
 	var prevTimestamp = 0.0
 	var prevBpm = 0.0
-	if !Global.bpms.is_empty():
-		Global.bpms.clear()
-		Global.bpm_timestamps.clear()
-		Global.bpm_beatstamps.clear()
+	if !bpms.is_empty():
+		bpms.clear()
+		bpm_timestamps.clear()
+		bpm_beatstamps.clear()
 	for mod in Save.keyframes.get('modifiers', Save.modifier_default):
-		Global.bpms.append(mod['bpm'])
-		Global.bpm_timestamps.append(mod['timestamp'])
+		bpms.append(mod['bpm'])
+		bpm_timestamps.append(mod['timestamp'])
 		cumulativeBeats += (mod['timestamp'] - prevTimestamp) * (prevBpm / 60)
-		Global.bpm_beatstamps.append(cumulativeBeats)
+		bpm_beatstamps.append(cumulativeBeats)
 		prevTimestamp = mod['timestamp']
 		prevBpm = mod['bpm']
-	song_beats_total = int(get_beat_at_time(Global.song_length))
+	song_beats_total = int(get_beat_at_time(song_length - offset))
 	
-	Global.mods_need_reapply = true
+	mods_need_reapply = true
 	
-	if Global.project_loaded:
+	if project_loaded:
 		Events.emit_signal('update_notespeed')
 		Events.emit_signal('update_bpm')
 
 func get_beat_at_time(time: float) -> float:
 	var idx = 1
-	while idx < Global.bpm_timestamps.size():
-		if Global.bpm_timestamps[idx] > time:
+	while idx < bpm_timestamps.size():
+		if bpm_timestamps[idx] > time:
 			break
 		idx += 1
-	return Global.bpm_beatstamps[idx-1] + ((time - Global.bpm_timestamps[idx-1]) * (Global.bpms[idx-1] / 60))
+	return bpm_beatstamps[idx-1] + ((time - bpm_timestamps[idx-1]) * (bpms[idx-1] / 60))
 
 func get_time_at_beat(beat: float) -> float:
 	var idx = 1
-	while idx < Global.bpm_beatstamps.size():
-		if Global.bpm_beatstamps[idx] > beat:
+	while idx < bpm_beatstamps.size():
+		if bpm_beatstamps[idx] > beat:
 			break
 		idx += 1
-	return Global.bpm_timestamps[idx-1] + ((beat - Global.bpm_beatstamps[idx-1]) * (1 / (Global.bpms[idx-1] / 60.0)))
+	return bpm_timestamps[idx-1] + ((beat - bpm_beatstamps[idx-1]) * (1 / (bpms[idx-1] / 60.0)))

--- a/src/gl_save.gd
+++ b/src/gl_save.gd
@@ -107,8 +107,8 @@ func load_song():
 	Global.music.stream = Global.load_mp3(path)
 	Global.song_length = Global.music.stream.get_length()
 	Global.reload_bpm()
-	Global.zoom_factor = 60.0/Save.keyframes.get('modifiers', Save.modifier_default)[0]['bpm']
-	Global.song_beats_total = int(Global.get_beat_at_time(Global.song_length))
+	Global.zoom_factor = 60.0/keyframes.get('modifiers', modifier_default)[0]['bpm']
+	Global.song_beats_total = int(Global.get_beat_at_time(Global.song_length - Global.offset))
 	Events.emit_signal('song_loaded')
 
 func load_chart(difficulty_index: int = 0) -> int:

--- a/src/gl_save.gd
+++ b/src/gl_save.gd
@@ -108,7 +108,7 @@ func load_song():
 	Global.song_length = Global.music.stream.get_length()
 	Global.reload_bpm()
 	Global.zoom_factor = 60.0/keyframes.get('modifiers', modifier_default)[0]['bpm']
-	Global.song_beats_total = int(Global.get_beat_at_time(Global.song_length - Global.offset))
+	Global.song_beats_total = ceil(Global.get_beat_at_time(Global.song_length - Global.offset))
 	Events.emit_signal('song_loaded')
 
 func load_chart(difficulty_index: int = 0) -> int:

--- a/src/gl_save.gd
+++ b/src/gl_save.gd
@@ -12,10 +12,17 @@ var settings: Dictionary
 var song_offset_default = 0.0
 var modifier_default = [{"bpm": 128.0, "timestamp": 0}]
 
+# Keep a copy of the original BPMs in memory. 
+# If these change, apply changes to all difficulties on save or load difficulty
+var original_modifiers: Array
+
 func save_project() -> void:
 	#Save keyframes
 	keyframes['loops'].sort_custom(func(a,b): return a['timestamp'] < b['timestamp'])
 	print('Could not save keyframes.cfg') if save_cfg('keyframes.cfg', keyframes) == FAILED else print('Saved keyframes.cfg')
+	
+	if Global.mods_need_reapply:
+		recalculate_all_notes()
 	
 	#Save Notes
 	notes['charts'][Global.difficulty_index]['notes'] = Global.current_chart # Move chart to save cache
@@ -73,7 +80,7 @@ func load_project(file_path):
 		Global.offset = settings.get('song_offset', song_offset_default)
 		
 		await get_tree().process_frame; await get_tree().physics_frame
-		Global.bpm_offset = 0; load_assets(); load_chart(); load_song()
+		load_assets(); load_song(); save_original_mods(); load_chart()
 		
 		Events.emit_signal('notify', 'Project Loaded', meta['level_name'], project_dir + "/thumb.png")
 		Events.emit_signal('project_loaded')
@@ -99,10 +106,9 @@ func load_song():
 	var path = project_dir + "/audio/" + asset.get('song_path', "")
 	Global.music.stream = Global.load_mp3(path)
 	Global.song_length = Global.music.stream.get_length()
-	Global.bpm_offset = Save.keyframes.get('modifiers', Save.modifier_default)[0]['timestamp']
 	Global.reload_bpm()
-	Global.global_bpm = Global.bpm
-	Global.beat_offset = 0
+	Global.zoom_factor = 60.0/Save.keyframes.get('modifiers', Save.modifier_default)[0]['bpm']
+	Global.song_beats_total = int(Global.get_beat_at_time(Global.song_length))
 	Events.emit_signal('song_loaded')
 
 func load_chart(difficulty_index: int = 0) -> int:
@@ -113,6 +119,8 @@ func load_chart(difficulty_index: int = 0) -> int:
 		notes['charts'][Global.difficulty_index]['notes'] = Global.current_chart.duplicate(true)
 		print('Storing previous chart')
 	Timeline.clear_notes_only()
+	if Global.mods_need_reapply:
+		recalculate_all_notes()
 	if notes != {}:
 		if notes['charts'].size() < 1:
 			create_difficulty()
@@ -132,3 +140,28 @@ func create_difficulty(diffcuilty_name: String = "Virgin", rating: int = 0, char
 		'notes': chart
 	}
 	notes['charts'].append(new_difficulty) 
+
+func save_original_mods():
+	original_modifiers = keyframes['modifiers'].duplicate(true)
+	var cumulativeBeats = 0.0
+	var prevTimestamp = 0.0
+	var prevBpm = 0.0
+	for mod in original_modifiers:
+		cumulativeBeats += (mod['timestamp'] - prevTimestamp) * (prevBpm / 60)
+		mod['beatstamp'] = cumulativeBeats
+		prevTimestamp = mod['timestamp']
+		prevBpm = mod['bpm']
+	Global.mods_need_reapply = false
+
+func recalculate_all_notes():
+	for i in notes['charts'].size():
+		if i == Global.difficulty_index: continue
+		for note in notes['charts'][i]['notes']:
+			var j = 1
+			while j < original_modifiers.size():
+				if original_modifiers[j]['timestamp'] > note['timestamp']:
+					break
+				j += 1
+			var beat = original_modifiers[j-1]['beatstamp'] + ((note['timestamp'] - original_modifiers[j-1]['timestamp']) * (original_modifiers[j-1]['bpm'] / 60))
+			note['timestamp'] = Global.get_time_at_beat(beat)
+	save_original_mods()

--- a/src/gl_timeline.gd
+++ b/src/gl_timeline.gd
@@ -134,7 +134,7 @@ func _input(event):
 			else:
 				if get_viewport().get_mouse_position().y > 872:
 					# Seeking
-					inc_scale = (Global.song_seconds_per_beat / 16) if !event.alt_pressed else 0.005
+					inc_scale = (Global.zoom_factor / 16) if !event.alt_pressed else 0.005
 					if event.button_index == MOUSE_BUTTON_WHEEL_UP:
 						clamp_seek(inc_scale)
 					if event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
@@ -170,7 +170,7 @@ func _input(event):
 				Events.emit_signal('update_notespeed')
 			else:
 				# Seeking
-				inc_scale = (Global.song_seconds_per_beat / 8) if !event.alt_pressed else 0.005
+				inc_scale = (Global.zoom_factor / 8) if !event.alt_pressed else 0.005
 				clamp_seek(inc_scale * event.delta.x)
 				scroll(-event.delta.y)
 	


### PR DESCRIPTION
* Smooth playback and scrubbing
* All indicators and guides visible all the time
* Node positioning is recalculated only when modifier nodes are changed
* All notes and other keyframes are snapped to their original beats when BPM is changed
   * Keeps stuff on the beat if you need to make minor BPM adjustments
   * Also allows you to edit BPM after notes in case that's how you roll
* The same changes are applied to all difficulties on difficulty change or project save
* Expanded BPM maximum and minimum range